### PR TITLE
README: fix link to LEF/DEF issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ collection scaling to 100s of actors.
 * Supports macro-to-macro, macro-to-boundary spacing constraints.
 * Allows users to specify their own technology parameters, e.g. and routing resources (in routes per micron) and macro routing allocation.
 * **Coming soon**: Tools for generating a clustered netlist given a netlist in common formats
-  (Bookshelf and [LEF/DEF](https://github.com/tfboyd/circuit_training/issues/1)).
+  (Bookshelf and [LEF/DEF](https://github.com/google-research/circuit_training/issues/3)).
 * **Coming soon**: Generates macro placement tcl command compatible with major EDA tools (Innovus, ICC2).
 
 


### PR DESCRIPTION
Currently it's pointing to a fork.