### PR TITLE
Bug fix for Grouping code.

### DIFF
--- a/circuit_training/grouping/grouper.py
+++ b/circuit_training/grouping/grouper.py
@@ -64,7 +64,7 @@ FLAGS = flags.FLAGS
 def setup_fixed_groups(grp: grouping.Grouping, output_dir: str,
                        fixed_logic_levels: int) -> str:
   fix_file = os.path.join(output_dir, 'metis_input.fix')
-  if gfile.Exists(fix_file):
+  if os.path.isfile(fix_file):
     update_groups_using_metis_output(grp, fix_file)
     return fix_file
 
@@ -78,8 +78,8 @@ def partition_netlist(plc: plc_client.PlacementCost, num_groups: int,
                       breakup: bool, output_dir: str, hmetis_opts: Any,
                       netlist_file: str) -> Optional[Tuple[str, str]]:
   """Partitions standard cells into groups by calling hmetis."""
-  if not gfile.IsDirectory(output_dir):
-    gfile.MakeDirs(output_dir)
+  if not os.path.isdir(output_dir):
+    os.makedirs(output_dir)
   metis_file = os.path.join(output_dir, 'metis_input')
 
   logging.info('Writing metis compatible file: %s', metis_file)
@@ -101,7 +101,7 @@ def partition_netlist(plc: plc_client.PlacementCost, num_groups: int,
     num_groups += num_fixed_groups
   else:
     fix_file = None
-  if gfile.Exists(metis_file):
+  if os.path.exists(metis_file):
     logging.warning('Metis input file exists, skipping generation.')
   else:
     try:

--- a/circuit_training/grouping/grouping.py
+++ b/circuit_training/grouping/grouping.py
@@ -512,7 +512,7 @@ class Grouping:
         if node.orientation is None:
           self.add_attr(new_node, "orientation", mnds.Orientation.N.name)
         else:
-          self.add_attr(new_node, "orientation", mnds.Orientation.name)
+          self.add_attr(new_node, "orientation", node.orientation.name)
 
     for group_no in groups_to_print:
       self.write_as_macro(group_no, graph_def)

--- a/circuit_training/grouping/hmetis_util.py
+++ b/circuit_training/grouping/hmetis_util.py
@@ -56,7 +56,7 @@ def call_hmetis(graph_file: str,
     Name of the metis output file, or None if no output is generated.
   """
   hmetis_exe = os.path.join(_HMETIS_DIR.value, 'hmetis')
-  assert gfile.Exists(hmetis_exe), f"{hmetis_exe} doesn't exist."
+  assert os.path.exists(hmetis_exe), f"{hmetis_exe} doesn't exist."
   args = [
       hmetis_exe, graph_file, fix_file, n_parts, ub_factor, n_runs, c_type,
       r_type, v_cycle, reconst, dbglvl


### PR DESCRIPTION
Hi,
I tried to run grouping code on the [synthesized netlist](https://drive.google.com/file/d/1s5WmiV-8led7XijUospFF0LML9oQ88aL/view?usp=sharing) generated using the flow given in this [GitHub repo](https://github.com/TILOS-AI-Institute/MacroPlacement/tree/flow_scripts).

I noticed grouper.py and hmetis_util.py uses gfile module to which we do not have access. So I replaced gfile with os.path.

The ariane_test.pb.txt netlist, available in the [grouping/testdata](https://github.com/google-research/circuit_training/tree/main/circuit_training/grouping/testdata) directory, does not contain macro orientation. If the input netlist contains macro orientation, then the [grouping.py](https://github.com/google-research/circuit_training/blob/main/circuit_training/grouping/grouping.py) errors out. So I have suggested one line change in the [grouping.py](https://github.com/google-research/circuit_training/blob/main/circuit_training/grouping/grouping.py).

I can run grouping code for [synthesized netlist](https://drive.google.com/file/d/1s5WmiV-8led7XijUospFF0LML9oQ88aL/view?usp=sharing) with the above suggested changes.

Sayak